### PR TITLE
Refactor: renombrar entidad New a SavedNew y servicio NewAppService a SavedNewsAppService

### DIFF
--- a/aspnet-core/src/Newslify.Application.Contracts/SavedNews/ISavedNewsAppService.cs
+++ b/aspnet-core/src/Newslify.Application.Contracts/SavedNews/ISavedNewsAppService.cs
@@ -5,10 +5,10 @@ using System.Threading.Tasks;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 
-namespace Newslify.News
+namespace Newslify.SavedNews
 {
-    public interface INewAppService : IApplicationService
+    public interface ISavedNewsAppService : IApplicationService
     {
-        Task<ICollection<NewDto>> GetNewsAsync();
+        Task<ICollection<SavedNewDto>> GetSavedNewsAsync();
     }
 }

--- a/aspnet-core/src/Newslify.Application.Contracts/SavedNews/SavedNewDto.cs
+++ b/aspnet-core/src/Newslify.Application.Contracts/SavedNews/SavedNewDto.cs
@@ -1,9 +1,9 @@
 using System;
 using Volo.Abp.Application.Dtos;
 
-namespace Newslify.News
+namespace Newslify.SavedNews
 {
-    public class NewDto : EntityDto<int>
+    public class SavedNewDto : EntityDto<int>
     {
         public string Description { get; set; }
         public string Author { get; set; }

--- a/aspnet-core/src/Newslify.Application/NewslifyApplicationAutoMapperProfile.cs
+++ b/aspnet-core/src/Newslify.Application/NewslifyApplicationAutoMapperProfile.cs
@@ -2,7 +2,7 @@
 using Newslify.Keywords;
 using Newslify.Languages;
 using Newslify.LogReadNews;
-using Newslify.News;
+using Newslify.SavedNews;
 using Newslify.ReadingLists;
 
 namespace Newslify;
@@ -15,7 +15,7 @@ public class NewslifyApplicationAutoMapperProfile : Profile
          * Alternatively, you can split your mapping configurations
          * into multiple profile classes for a better organization. */
         CreateMap<Language, LanguageDto>();
-        CreateMap<New, NewDto>();
+        CreateMap<SavedNew, SavedNewDto>();
         CreateMap<Keyword, KeywordDto>();
         CreateMap<LogReadNew, LogReadNewDto>();
         CreateMap<ReadingList, ReadingListDto>();

--- a/aspnet-core/src/Newslify.Application/SavedNews/SavedNewsAppService.cs
+++ b/aspnet-core/src/Newslify.Application/SavedNews/SavedNewsAppService.cs
@@ -7,22 +7,22 @@ using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 
-namespace Newslify.News
+namespace Newslify.SavedNews
 {
-    public class NewAppService : NewslifyAppService, INewAppService
+    public class SavedNewsAppService : NewslifyAppService, ISavedNewsAppService
     {
-        private readonly IRepository<New, int> _repository;
+        private readonly IRepository<SavedNew, int> _repository;
 
-        public NewAppService(IRepository<New, int> repository)
+        public SavedNewsAppService(IRepository<SavedNew, int> repository)
         {
             _repository = repository;
         }
 
-        public async Task<ICollection<NewDto>> GetNewsAsync()
+        public async Task<ICollection<SavedNewDto>> GetSavedNewsAsync()
         {
-            var news = await _repository.GetListAsync();
+            var savedNews = await _repository.GetListAsync();
 
-            return ObjectMapper.Map<ICollection<New>, ICollection<NewDto>>(news);
+            return ObjectMapper.Map<ICollection<SavedNew>, ICollection<SavedNewDto>>(savedNews);
         }
 
         /* public async Task<ThemeDto> GetThemesAsync(int id)

--- a/aspnet-core/src/Newslify.Domain/Keywords/Keyword.cs
+++ b/aspnet-core/src/Newslify.Domain/Keywords/Keyword.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Volo.Abp.Domain.Entities;
 using Newslify.ReadingLists;
-using Newslify.News;
+using Newslify.SavedNews;
 
 namespace Newslify.Keywords
 {
@@ -13,6 +13,6 @@ namespace Newslify.Keywords
     {
         public string KeyWord { get; set; }
         public ICollection<ReadingList> ReadingLists { get; set; }
-        public ICollection<New> News { get; set; }
+        public ICollection<SavedNew> SavedNews { get; set; }
     }
 }

--- a/aspnet-core/src/Newslify.Domain/ReadingLists/ReadingList.cs
+++ b/aspnet-core/src/Newslify.Domain/ReadingLists/ReadingList.cs
@@ -7,7 +7,7 @@ using Volo.Abp.Domain.Entities;
 using Volo.Abp.Identity;
 using Newslify.Keywords;
 using Abp.Authorization.Users;
-using Newslify.News;
+using Newslify.SavedNews;
 
 namespace Newslify.ReadingLists
 {
@@ -23,6 +23,6 @@ namespace Newslify.ReadingLists
 		public ReadingList? ParentReadingList { get; set; }
 
 		public ICollection<Keyword> Keywords { get; set; }
-		public ICollection<New> News { get; set; }
+		public ICollection<SavedNew> SavedNews { get; set; }
 	}
 }

--- a/aspnet-core/src/Newslify.Domain/SavedNews/SavedNew.cs
+++ b/aspnet-core/src/Newslify.Domain/SavedNews/SavedNew.cs
@@ -7,9 +7,9 @@ using System.Text;
 using System.Threading.Tasks;
 using Volo.Abp.Domain.Entities;
 
-namespace Newslify.News
+namespace Newslify.SavedNews
 {
-    public class New : Entity<int>
+    public class SavedNew : Entity<int>
     {
         public string Description { get; set; }
         public string Author { get; set; }

--- a/aspnet-core/src/Newslify.EntityFrameworkCore/EntityFrameworkCore/NewslifyDbContext.cs
+++ b/aspnet-core/src/Newslify.EntityFrameworkCore/EntityFrameworkCore/NewslifyDbContext.cs
@@ -15,7 +15,7 @@ using Volo.Abp.TenantManagement.EntityFrameworkCore;
 using Newslify.Languages;
 using Newslify.ReadingLists;
 using Newslify.Keywords;
-using Newslify.News;
+using Newslify.SavedNews;
 using Newslify.LogReadNews;
 using Volo.Abp.EntityFrameworkCore.Modeling;
 
@@ -64,7 +64,7 @@ public class NewslifyDbContext :
     public DbSet<Language> Languages { get; set; }
     public DbSet<ReadingList> ReadingLists { get; set; }
     public DbSet<Keyword> Keywords { get; set; }
-    public DbSet<New> News { get; set; }
+    public DbSet<SavedNew> SavedNews { get; set; }
     public DbSet<LogReadNew> LogReadNews { get; set; }
 
     #endregion
@@ -116,9 +116,9 @@ public class NewslifyDbContext :
         });
 
         /* New Entity*/
-        builder.Entity<New>(b =>
+        builder.Entity<SavedNew>(b =>
         {
-            b.ToTable(NewslifyConsts.DbTablePrefix + "News", NewslifyConsts.DbSchema);
+            b.ToTable(NewslifyConsts.DbTablePrefix + "SavedNews", NewslifyConsts.DbSchema);
             b.ConfigureByConvention();
             b.Property(x => x.Description).IsRequired().HasMaxLength(256);
             b.Property(x => x.Author).IsRequired().HasMaxLength(128);

--- a/aspnet-core/src/Newslify.EntityFrameworkCore/Migrations/20231011201911_rename_new_entity.Designer.cs
+++ b/aspnet-core/src/Newslify.EntityFrameworkCore/Migrations/20231011201911_rename_new_entity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Newslify.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore;
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Newslify.Migrations
 {
     [DbContext(typeof(NewslifyDbContext))]
-    partial class NewslifyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231011201911_rename_new_entity")]
+    partial class renamenewentity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/aspnet-core/src/Newslify.EntityFrameworkCore/Migrations/20231011201911_rename_new_entity.cs
+++ b/aspnet-core/src/Newslify.EntityFrameworkCore/Migrations/20231011201911_rename_new_entity.cs
@@ -1,0 +1,186 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Newslify.Migrations
+{
+    /// <inheritdoc />
+    public partial class renamenewentity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "KeywordNew");
+
+            migrationBuilder.DropTable(
+                name: "NewReadingList");
+
+            migrationBuilder.DropTable(
+                name: "AppNews");
+
+            migrationBuilder.CreateTable(
+                name: "AppSavedNews",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Description = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    Author = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    Url = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    Source = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppSavedNews", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "KeywordSavedNew",
+                columns: table => new
+                {
+                    KeywordsId = table.Column<int>(type: "int", nullable: false),
+                    SavedNewsId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_KeywordSavedNew", x => new { x.KeywordsId, x.SavedNewsId });
+                    table.ForeignKey(
+                        name: "FK_KeywordSavedNew_AppKeywords_KeywordsId",
+                        column: x => x.KeywordsId,
+                        principalTable: "AppKeywords",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_KeywordSavedNew_AppSavedNews_SavedNewsId",
+                        column: x => x.SavedNewsId,
+                        principalTable: "AppSavedNews",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ReadingListSavedNew",
+                columns: table => new
+                {
+                    ReadingListsId = table.Column<int>(type: "int", nullable: false),
+                    SavedNewsId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReadingListSavedNew", x => new { x.ReadingListsId, x.SavedNewsId });
+                    table.ForeignKey(
+                        name: "FK_ReadingListSavedNew_AppReadingLists_ReadingListsId",
+                        column: x => x.ReadingListsId,
+                        principalTable: "AppReadingLists",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ReadingListSavedNew_AppSavedNews_SavedNewsId",
+                        column: x => x.SavedNewsId,
+                        principalTable: "AppSavedNews",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_KeywordSavedNew_SavedNewsId",
+                table: "KeywordSavedNew",
+                column: "SavedNewsId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadingListSavedNew_SavedNewsId",
+                table: "ReadingListSavedNew",
+                column: "SavedNewsId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "KeywordSavedNew");
+
+            migrationBuilder.DropTable(
+                name: "ReadingListSavedNew");
+
+            migrationBuilder.DropTable(
+                name: "AppSavedNews");
+
+            migrationBuilder.CreateTable(
+                name: "AppNews",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Author = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    Source = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    Url = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppNews", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "KeywordNew",
+                columns: table => new
+                {
+                    KeywordsId = table.Column<int>(type: "int", nullable: false),
+                    NewsId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_KeywordNew", x => new { x.KeywordsId, x.NewsId });
+                    table.ForeignKey(
+                        name: "FK_KeywordNew_AppKeywords_KeywordsId",
+                        column: x => x.KeywordsId,
+                        principalTable: "AppKeywords",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_KeywordNew_AppNews_NewsId",
+                        column: x => x.NewsId,
+                        principalTable: "AppNews",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NewReadingList",
+                columns: table => new
+                {
+                    NewsId = table.Column<int>(type: "int", nullable: false),
+                    ReadingListsId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NewReadingList", x => new { x.NewsId, x.ReadingListsId });
+                    table.ForeignKey(
+                        name: "FK_NewReadingList_AppNews_NewsId",
+                        column: x => x.NewsId,
+                        principalTable: "AppNews",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_NewReadingList_AppReadingLists_ReadingListsId",
+                        column: x => x.ReadingListsId,
+                        principalTable: "AppReadingLists",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_KeywordNew_NewsId",
+                table: "KeywordNew",
+                column: "NewsId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NewReadingList_ReadingListsId",
+                table: "NewReadingList",
+                column: "ReadingListsId");
+        }
+    }
+}


### PR DESCRIPTION
Cambio todo de nombre porque representa la noticia que el usuario guardo en alguna lista y no una entidad noticia en si. Mas que nada porque despues va a haber un servicio NewsAppService que devuelva las noticias de la API newsAPI.org