### PR TITLE
fix: NewsService funcionando y devolviendo noticias

### DIFF
--- a/aspnet-core/src/Newslify.Application/News/NewsAppService.cs
+++ b/aspnet-core/src/Newslify.Application/News/NewsAppService.cs
@@ -17,7 +17,7 @@ namespace Newslify
         public async Task<string> GetNewsAsync(string LanguageIntCode, int amountNews)
          {
            var newsAPI = new HandlerNewsAPI();
-           string newsInJSON = await newsAPI.getNews("EN",1);// metodo que se conecte a la API y traiga las noticias
+           string newsInJSON = await newsAPI.getNews(LanguageIntCode.ToUpper(),amountNews);// metodo que se conecte a la API y traiga las noticias
 
            return newsInJSON;
          }

--- a/aspnet-core/src/Newslify.Domain/API/HandlerNewsAPI.cs
+++ b/aspnet-core/src/Newslify.Domain/API/HandlerNewsAPI.cs
@@ -18,10 +18,13 @@ public class HandlerNewsAPI : INewsAPI
     {
         var articlesResponse = newsApiClient.GetEverything(new EverythingRequest
         {
+            Q = "news", // Filtro poco especifico para que devuelva noticias en general (necesario ya que sin filtro lo rechaza la API)
             SortBy = SortBys.Popularity,
             Language = Languages.EN, // Reveer como hacer para setearle distintos lenguajes
-            From = GetDateMonthAgoFromNow() // deberia obtener un DateTime un mes atras cada vez
-        });
+            From = GetDateMonthAgoFromNow(), // deberia obtener un DateTime un mes atras cada vez
+            Page = 1,
+            PageSize = amountNews ?? 20
+        }) ;
 
         if (articlesResponse.Status == Statuses.Ok)
         {


### PR DESCRIPTION
El servicio News ahora devuelve noticias en format string de JSON (el receptor deberia parsearlo tal como funcionan la mayoria de APIS) usando el endpoint GetEverything de NewsAPI.