### PR TITLE
feat: agregar posibilidad de pasar una query al getNews para la busqueda del usuario

### DIFF
--- a/aspnet-core/src/Newslify.Application.Contracts/News/INewsAppService.cs
+++ b/aspnet-core/src/Newslify.Application.Contracts/News/INewsAppService.cs
@@ -6,7 +6,7 @@ using Volo.Abp.Application.Services;
 
     public interface INewsAppService : IApplicationService
     {
-        Task<string> GetNewsAsync(string LanguageIntCode, int amountNews);
+        Task<string> GetNewsAsync(string LanguageIntCode, int? amountNews, string? query);
     }
 
 

--- a/aspnet-core/src/Newslify.Application/News/NewsAppService.cs
+++ b/aspnet-core/src/Newslify.Application/News/NewsAppService.cs
@@ -14,10 +14,10 @@ namespace Newslify
         {
         }
 
-        public async Task<string> GetNewsAsync(string LanguageIntCode, int amountNews)
+        public async Task<string> GetNewsAsync(string LanguageIntCode, int? amountNews, string? query)
          {
            var newsAPI = new HandlerNewsAPI();
-           string newsInJSON = await newsAPI.getNews(LanguageIntCode.ToUpper(),amountNews);// metodo que se conecte a la API y traiga las noticias
+           string newsInJSON = await newsAPI.getNews(LanguageIntCode.ToUpper(),amountNews, query);// metodo que se conecte a la API y traiga las noticias
 
            return newsInJSON;
          }

--- a/aspnet-core/src/Newslify.Domain/API/HandlerNewsAPI.cs
+++ b/aspnet-core/src/Newslify.Domain/API/HandlerNewsAPI.cs
@@ -14,14 +14,14 @@ public class HandlerNewsAPI : INewsAPI
       newsApiClient = new NewsApiClient("10a2a9fc820944829819bd5ab8d705e0"); // deberia estar en una variable de entorno
     }
 
-    public async Task<string> getNews(string LanguageIntCode, int? amountNews)
+    public async Task<string> getNews(string LanguageIntCode, int? amountNews, string? query)
     {
         var articlesResponse = newsApiClient.GetEverything(new EverythingRequest
         {
-            Q = "news", // Filtro poco especifico para que devuelva noticias en general (necesario ya que sin filtro lo rechaza la API)
+            Q = query ?? "news", // Si no te pasan nada, aplica "news", un filtro poco especifico para que devuelva noticias en general 
             SortBy = SortBys.Popularity,
-            Language = GetLanguage(LanguageIntCode), // Reveer como hacer para setearle distintos lenguajes
-            From = GetDateMonthAgoFromNow(), // deberia obtener un DateTime un mes atras cada vez
+            Language = GetLanguage(LanguageIntCode),
+            From = GetDateMonthAgoFromNow(),
             Page = 1,
             PageSize = amountNews ?? 20
         }) ;
@@ -42,6 +42,7 @@ public class HandlerNewsAPI : INewsAPI
         return date;
     }
 
+    // Analiza los case segun los valores del data seeder de la db. LanguageIntCode seria el languageId del usuario.
     private NewsAPI.Constants.Languages GetLanguage(string LanguageIntCode)
     {
         switch (LanguageIntCode)

--- a/aspnet-core/src/Newslify.Domain/API/INewsAPI.cs
+++ b/aspnet-core/src/Newslify.Domain/API/INewsAPI.cs
@@ -3,5 +3,5 @@ using System.Threading.Tasks;
 
 public interface INewsAPI
 {
-     Task<string> getNews(string LanguageIntCode, int? amountNews);
+     Task<string> getNews(string LanguageIntCode, int? amountNews, string? query);
 }


### PR DESCRIPTION
Al metodo que devolvia las noticias segun lenguaje y cantidad de noticias (opcional este ultimo param) que se le pasaban por parametro, se le agrego uno nuevo  (y opcional) "query" que se usa para pegarle a la API y que devuelva noticias de ese tema. 

Sera util para cuando un usuario haga una busqueda, esa cadena a buscar sera esa "query" que le llega en la peticion.